### PR TITLE
Kubernetes controllers. ReplicaSet, Deployment, DaemonSet

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hw-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: static-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: static-server
+    spec:
+      containers:
+      - name: static-server
+        image: kali7va/static-server
+        env:
+        - name: SERVER_PORT
+          value: "8000"
+        - name: STATIC_RESOURCES
+          value: "/homework"
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          exec:
+            command: ["test", "-f", "/homework/index.html"]
+        volumeMounts:
+        - name: workdir
+          mountPath: /homework
+        lifecycle:
+          preStop:
+            exec:
+              command: ["rm", "/homework/index.html"]
+      initContainers:
+      - name: busybox
+        image: busybox:1.28
+        command: ["wget", "-O", "/init/index.html", "http://info.cern.ch"]
+        volumeMounts:
+        - name: workdir
+          mountPath: /init
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      nodeSelector:
+        homework: 'true'

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Описан манифест для создания деплоймента 3х экземпляров  подов, со стратегией обновления `RollingUpdate`, проверкой на готовность и селектором, который позволяет деплоить поды только на ноде с меткой `homework=true`

## Как запустить проект:
 - В директории `kubernetes-controllers` выполнить `kubectl apply -f .`

## Как проверить работоспособность:
 - Выполнить `kubectl get po -n homework` и убедиться, что успешно запущены три пода 
 - Войти в контейнер любого пода - по запросу `curl localhost:8000` должна возвращаться html страница

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
